### PR TITLE
Add support for Debian distro

### DIFF
--- a/lib/puppet/provider/osd/ceph_disk.rb
+++ b/lib/puppet/provider/osd/ceph_disk.rb
@@ -71,7 +71,11 @@ private
     # Parameter list is stripped of leading hyphens
     # An undefined value is an option without an argument
     params.map do |k, v|
-      v == :undef && "--#{k}" || "--#{k} #{v}"
+      if v == :undef or v.empty?
+        "--#{k}"
+      else
+        "--#{k} #{v}"
+      end
     end.join(' ')
   end
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,15 @@
 class ceph::params {
 
   case $::facts['os']['name'] {
+    'Debian': {
+      if versioncmp($::facts['os']['release']['major'], '8') >= 0 {
+        $service_provider = 'systemd'
+      } else {
+        err('This module has not been tested against Debian wheezy')
+      }
+      $radosgw_package = 'radosgw'
+      $prerequisites = []
+     }
     'Ubuntu': {
       if versioncmp($::facts['os']['release']['full'], '16.04') >= 0 {
         $service_provider = 'systemd'

--- a/metadata.json
+++ b/metadata.json
@@ -10,6 +10,10 @@
   "tags": ["ceph"],
   "operatingsystem_support": [
     {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [ "8", "9" ]
+    },
+    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [ "14.04", "16.04" ]
     },


### PR DESCRIPTION
Adds support for Debian 8 and above by setting the appropriate parameters. Though Ceph is available for Debian 7, it is `initd`-based and I have coded behavior identical to an unsupported OS. 