### PR TITLE
create config keys only on mon nodes

### DIFF
--- a/manifests/configkeys.pp
+++ b/manifests/configkeys.pp
@@ -6,9 +6,11 @@ class ceph::configkeys {
 
   assert_private()
 
-  $::ceph::config_keys.each |$key, $value| {
-    ceph::configkey { $key:
-      value => $value,
+  if $::ceph::mon {
+    $::ceph::config_keys.each |$key, $value| {
+      ceph::configkey { $key:
+        value => $value,
+      }
     }
   }
 


### PR DESCRIPTION
If there are config keys to be configured (which there are by default in this module) and there's no admin keyring on the host, deployment will fail. This PR fixes this bug.