### PR TITLE
Add support for Debian 8 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ the special name `defaults`.
 | 1.5.x   | Ubuntu 14.04, Ubuntu 16.04\*, Centos 7 | 10   | 3, 4   |
 | 2.0.x   | Ubuntu 14.04, Ubuntu 16.04\*, Centos 7 | 10   | 3, 4   |
 | 3.1.x   | Ubuntu 14.04, Ubuntu 16.04, Centos 7   | 10   | 4      |
-| 3.2.x   | Ubuntu 16.04, Centos 7                 | 12   | 4      |
+| 3.2.x   | Debian 8+9, Ubuntu 16.04, Centos 7     | 12   | 4, 5   |
 
 \* Ubuntu 16.04 only tested with Puppet 4
+\* Debian 8+9 only tested with Puppet 5
 
 ## Usage
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,12 +4,12 @@
 #
 class ceph::params {
 
-  case $::facts['os']['name'] {
-    'Ubuntu': {
+  case $::facts['os']['family'] {
+    'Debian': {
       $radosgw_package = 'radosgw'
       $prerequisites = []
     }
-    'RedHat', 'Centos': {
+    'RedHat': {
       $radosgw_package = 'ceph-radosgw'
       $prerequisites = [
         'redhat-lsb-core',            # Broken on centos with 0.94.6

--- a/metadata.json
+++ b/metadata.json
@@ -10,8 +10,12 @@
   "tags": ["ceph"],
   "operatingsystem_support": [
     {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [ "8", "9" ]
+    },
+    {
       "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [ "14.04", "16.04" ]
+      "operatingsystemrelease": [ "16.04" ]
     },
     {
       "operatingsystem": "Centos",


### PR DESCRIPTION
A cleaner version of pull request #6 to add support for Debian 8 and above. The branch this is pulling from won't change any further. The package names for Debian and Ubuntu are, not surprisingly, the same so I have adopted the OS family fact rather than the OS name.

I've also gone through and remove claimed Ubuntu 14.04 support which I believe you are intending to stop supporting with this module.