### PR TITLE
Added support for 'SLOT ###' disk references

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ based on whether ceph-disk has been run.
 The OSD provider can also operate on enclosures with SES firmware running on
 a SAS expander.  In some cases SCSI addresses aren't predicatable and susceptible
 to the same enumeration problem as /dev device names.  In these cases the devices
-can be provisioned with 'Slot 01' which directly correlates to a slot name
-found in sysfs under /sys/class/enclosure.  On newer expanders the labels may be
-formatted as DISK00 which is also supported.  The two addressing modes can be used
-interchangably.
+can be provisioned with 'Slot 01' or 'SLOT 001' which directly correlates to a
+slot name found in sysfs under /sys/class/enclosure.  On newer expanders the
+labels may be formatted as DISK00 which is also supported.  The two addressing
+modes can be used interchangably.
 
 The OSD provider also accepts an arbitrary hash of parameters to be passed to
 ceph-disk.  The keys are the long options supported by ceph-disk stripped of the

--- a/lib/puppet/provider/osd/ceph_disk.rb
+++ b/lib/puppet/provider/osd/ceph_disk.rb
@@ -26,7 +26,7 @@ private
 
   # Translate a slot number into a device node
   # Params:
-  # +slot+:: Slot number of the SAS expander e.g. "Slot 02"
+  # +slot+:: Slot number of the SAS expander e.g. "Slot 02", "SLOT 002"
   def self.enclosure_slot_to_dev(slot)
     # Get the expander
     # TODO: Supports one enclosure services device, need a way of reliably
@@ -49,7 +49,7 @@ private
   def self.identifier_to_dev(identifier)
     if identifier.start_with?('/dev/')
       identifier
-    elsif identifier.start_with?('Slot', 'DISK')
+    elsif identifier.start_with?('SLOT', 'Slot', 'DISK')
       enclosure_slot_to_dev(identifier)
     elsif identifier =~ /^\d+:\d+:\d+:\d+$/
       scsi_address_to_dev(identifier)

--- a/lib/puppet/type/osd.rb
+++ b/lib/puppet/type/osd.rb
@@ -17,6 +17,14 @@
 #   },
 # }
 #
+# osd { 'SLOT 001':
+#   journal => 'SLOT 001',
+#   params => {
+#     'bluetore' => undef,
+#     'fstype'   => 'xfs',
+#   },
+# }
+#
 Puppet::Type.newtype(:osd) do
   @doc = 'Create an OSD based on physical hardware address'
 
@@ -70,8 +78,8 @@ Puppet::Type.newtype(:osd) do
     return if address.start_with?('/dev/')
     # SCSI address e.g. 1:0:0:0
     return if address =~ /^\d+:\d+:\d+:\d+$/
-    # Expander slot e.g. Slot 01, DISK00
-    return if address =~ /^(Slot \d{2}|DISK\d{2})$/
+    # Expander slot e.g. SLOT 001, Slot 01, DISK00
+    return if address =~ /^(SLOT \d{3}|Slot \d{2}|DISK\d{2})$/
     raise ArgumentError, 'osd::validate_address invalid value'
   end
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,9 @@
 # [*package_ensure*]
 #   Ceph version to install
 #
+# [*package_options*]
+#   install_options for the Ceph package
+#
 # [*user*]
 #   Username ceph runs as
 #
@@ -78,6 +81,7 @@ class ceph (
   String $repo_version = 'luminous',
   # Package management
   String $package_ensure = 'installed',
+  String $package_options = 'undef',
   # User management
   String $user = 'ceph',
   String $group = 'ceph',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,7 +5,8 @@ class ceph::install {
   assert_private()
 
   package { 'ceph':
-    ensure => $::ceph::package_ensure,
+    ensure          => $::ceph::package_ensure,
+    install_options => $::ceph::package_options,
   }
 
   if $::facts['os']['name'] == 'Ubuntu' {

--- a/spec/unit/puppet/type/osd_spec.rb
+++ b/spec/unit/puppet/type/osd_spec.rb
@@ -26,6 +26,12 @@ describe Puppet::Type.type(:osd) do
 
     it 'accepts slot IDs' do
       expect do
+        described_class.new(:name => 'SLOT 001')
+      end.to_not raise_error
+    end
+
+    it 'accepts slot IDs' do
+      expect do
         described_class.new(:name => 'Slot 01')
       end.to_not raise_error
     end
@@ -63,6 +69,12 @@ describe Puppet::Type.type(:osd) do
     it 'accepts scsi addresses' do
       expect do
         described_class.new(:name => '0:0:0:0', :journal => '1:0:0:0')
+      end.to_not raise_error
+    end
+
+    it 'accepts slot IDs' do
+      expect do
+        described_class.new(:name => '0:0:0:0', :journal => 'SLOT 001')
       end.to_not raise_error
     end
 

--- a/templates/ceph.conf.erb
+++ b/templates/ceph.conf.erb
@@ -1,6 +1,6 @@
-<% @_conf.each do |section, setting_value| -%>
+<% @_conf.sort.map do |section, setting_value| -%>
 [<%= section %>]
-<% setting_value.each do |setting, value| -%>
+<% setting_value.sort.map do |setting, value| -%>
   <%= setting %> = <%= value %>
 <% end -%>
 <% end -%>

--- a/types/disk.pp
+++ b/types/disk.pp
@@ -1,6 +1,7 @@
 type Ceph::Disk = Pattern[
   /\A\/dev\/[\w\d]+\Z/,
   /\A\d+:\d+:\d+:\d+\Z/,
+  /\ASLOT \d{3}\Z/,
   /\ASlot \d{2}\Z/,
   /\ADISK\d{2}\Z/,
 ]

--- a/types/keys.pp
+++ b/types/keys.pp
@@ -7,4 +7,7 @@ type Ceph::Keys = Hash[String[1], Struct[{
     Optional[mgr] => String[1],
   }],
   Optional[path]     => String[1],
+  Optional[owner]    => String[1],
+  Optional[group]    => String[1],
+  Optional[mode]     => String[1],
 }]]


### PR DESCRIPTION
In addition to 'Slot ##' and 'DISK##'.

On our (IBM xSeries) hardware, we have e.g.
/sys/class/enclosure/0:0:8:0/SLOT 000/device/block/sda