### PR TITLE
change the default listening address of mgr dashboard to ::

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -107,7 +107,7 @@ class ceph (
     },
   },
   Ceph::ConfigKeys $config_keys = {
-    'mgr/dashboard/server_addr' => '0.0.0.0',
+    'mgr/dashboard/server_addr' => '::',
     'mgr/dashboard/server_port' => 7000,
   },
   # Monitor configuration


### PR DESCRIPTION
This changes the listening address of the mgr dashboard to be configured by default to ::. This will make the dashboard listen on all IPv4 and IPv6 addresses. This is Ceph's default value if no address is configured.